### PR TITLE
test on multiple python versions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,6 +22,9 @@ jobs:
           - name: mypy
             python-version: 3.8
             tox-env: mypy
+          - name: python3.5 django2
+            python-version: 3.5
+            tox-env: py3-django2
           - name: python3.8 django2
             python-version: 3.8
             tox-env: py3-django2

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,6 +40,12 @@ jobs:
           - name: python3.8 django4
             python-version: 3.8
             tox-env: py3-django4
+          - name: python3.10 django3
+            python-version: '3.10'
+            tox-env: py3-django3
+          - name: python3.10 django4
+            python-version: '3.10'
+            tox-env: py3-django4
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6,16 +6,31 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8]
-        tox-env:
-          - py3-django2
-          - py3-django3
-          - py3-django4
-          - bandit
-          - black
-          - flake8
-          - isort
-          - mypy
+        include:
+          - name: bandit
+            python-version: 3.8
+            tox-env: bandit
+          - name: black
+            python-version: 3.8
+            tox-env: black
+          - name: flake8
+            python-version: 3.8
+            tox-env: flake8
+          - name: isort
+            python-version: 3.8
+            tox-env: isort
+          - name: mypy
+            python-version: 3.8
+            tox-env: mypy
+          - name: python3.8 django2
+            python-version: 3.8
+            tox-env: py3-django2
+          - name: python3.8 django3
+            python-version: 3.8
+            tox-env: py3-django3
+          - name: python3.8 django4
+            python-version: 3.8
+            tox-env: py3-django4
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,6 +25,12 @@ jobs:
           - name: python3.5 django2
             python-version: 3.5
             tox-env: py3-django2
+          - name: python3.6 django2
+            python-version: 3.6
+            tox-env: py3-django2
+          - name: python3.6 django3
+            python-version: 3.6
+            tox-env: py3-django3
           - name: python3.8 django2
             python-version: 3.8
             tox-env: py3-django2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include MANIFEST.in
 include tox.ini
 include runtests.py
+include README.md
 graft src
 graft tests


### PR DESCRIPTION
Add tests on python3.5 (only Django 2), python3.6 (Django 2 and 3), and python 3.10 (Django 3 and 4). I think that pretty much covers all the environments we run or will likely run in the near future.